### PR TITLE
Adding support for O365 Add-on for Splunk

### DIFF
--- a/cyences_app_for_splunk/default/savedsearches.conf
+++ b/cyences_app_for_splunk/default/savedsearches.conf
@@ -2256,7 +2256,7 @@ display.page.search.mode = fast
 display.visualizations.show = 0
 request.ui_dispatch_app = cyences_app_for_splunk
 request.ui_dispatch_view = search
-search = `cs_o365` sourcetype="ms:o365:reporting:messagetrace" \
+search = `cs_o365` sourcetype="ms:o365:reporting:messagetrace" OR sourcetype="o365:reporting:messagetrace" \
 | bin span=1h _time \
 | stats dc(MessageId) as count by SenderAddress, _time \
 | stats avg(count) as avg, stdev(count) as stdev by SenderAddress \

--- a/cyences_app_for_splunk/default/savedsearches.conf
+++ b/cyences_app_for_splunk/default/savedsearches.conf
@@ -2283,7 +2283,7 @@ display.page.search.tab = statistics
 display.page.search.mode = fast
 request.ui_dispatch_app = cyences_app_for_splunk
 request.ui_dispatch_view = search
-search = `cs_o365` sourcetype="ms:o365:reporting:messagetrace" _index_earliest=-61m@m _index_latest=-1m@m \
+search = `cs_o365` sourcetype="ms:o365:reporting:messagetrace" OR sourcetype="o365:reporting:messagetrace" _index_earliest=-61m@m _index_latest=-1m@m \
 | stats dc(MessageId) as count, values(Subject) as Subject by SenderAddress \
 | lookup cs_email_sent_upperbound.csv SenderAddress OUTPUT upperBound, avg, stdev \
 | where count>upperBound AND count > `cs_email_increase_over_baseline_limit` \
@@ -2316,7 +2316,7 @@ display.page.search.tab = statistics
 display.page.search.mode = fast
 request.ui_dispatch_app = cyences_app_for_splunk
 request.ui_dispatch_view = search
-search = `cs_o365` sourcetype="ms:o365:reporting:messagetrace" _index_earliest=-25h@m _index_latest=-1h@m Status=FilteredAsSpam \
+search = `cs_o365` sourcetype="ms:o365:reporting:messagetrace" OR sourcetype="o365:reporting:messagetrace" _index_earliest=-25h@m _index_latest=-1h@m Status=FilteredAsSpam \
 | stats count, values(RecipientAddress) as RecipientAddress by SenderAddress, Subject \
 | eval cyences_severity = "info" \
 | sort - count \


### PR DESCRIPTION
In Splunk Add-on for O365, sourcetype for messagetrace logs is o365:reporting:messagetrace instead of ms:o365:reporting:messagetrace.