### PR TITLE
Updated the sophos alerts

### DIFF
--- a/cyences_app_for_splunk/default/props.conf
+++ b/cyences_app_for_splunk/default/props.conf
@@ -553,7 +553,6 @@ EVAL-dest_name = mvappend(DNS, NETBIOS)
 # For Cyences Assets datamodel
 FIELDALIAS-asset_id = HOST_ID AS asset_id
 FIELDALIAS-asset_ip = IP AS asset_ip
-LOOKUP-qualys_kb_lookup = qualys_kb_lookup QID OUTPUT TITLE as description
 EVAL-asset_hostname = mvjoin(mvappend(DNS, NETBIOS), "~~")
 EVAL-state = "Active"
 

--- a/cyences_app_for_splunk/default/props.conf
+++ b/cyences_app_for_splunk/default/props.conf
@@ -553,7 +553,7 @@ EVAL-dest_name = mvappend(DNS, NETBIOS)
 # For Cyences Assets datamodel
 FIELDALIAS-asset_id = HOST_ID AS asset_id
 FIELDALIAS-asset_ip = IP AS asset_ip
-
+LOOKUP-qualys_kb_lookup = qualys_kb_lookup QID OUTPUT TITLE as description
 EVAL-asset_hostname = mvjoin(mvappend(DNS, NETBIOS), "~~")
 EVAL-state = "Active"
 

--- a/cyences_app_for_splunk/default/savedsearches.conf
+++ b/cyences_app_for_splunk/default/savedsearches.conf
@@ -2895,22 +2895,30 @@ alert.suppress = 0
 counttype = number of events
 quantity = 0
 relation = greater than
-cron_schedule = 2,17,32,47 * * * *
+cron_schedule = 2,32 * * * *
 description = This alert will trigger when RealTime Protection is disabled on a Sophos endpoint. \
 \
 Data Collection - Sophos Central SIEM Integration Add-on (https://splunkbase.splunk.com/app/4647/) \
 \
 A false positive may appear when an administrator might have intentionally disabled RealTime Protection for Sophos. 
-dispatch.earliest_time = -17m@m
-dispatch.latest_time = -2m@m
+dispatch.earliest_time = 0
+dispatch.latest_time = now
 display.general.type = statistics
 display.page.search.tab = statistics
 display.page.search.mode = fast
 request.ui_dispatch_app = cyences_app_for_splunk
 request.ui_dispatch_view = search
-search = `cs_sophos` type="Event::Endpoint::SavDisabled" \
-| stats count, latest(_time) as _time, values(src_ip) as src_ip, values(suser) as user by host, dhost \
-| eval cyences_severity = "high" \
+# Search triggers critical alerts if RealTime Protection is disabled for more than three hours, otherwise it triggers high severity alerts.
+# In order to avoid duplicate alerts having high severity, the search is running in 2 diff timeranges and merging its result.
+search = `cs_sophos` type="Event::Endpoint::Sav*" earliest=-4h@m latest=-2m@m \
+| stats count, latest(_time) as _time, latest(type) as type, values(src_ip) as src_ip, values(suser) as user by host, dhost \
+| where type=="Event::Endpoint::SavDisabled" and _time < relative_time(now(), "-3h@m") \
+| eval cyences_severity = "critical" \
+| append \
+    [| search `cs_sophos` type="Event::Endpoint::Sav*" earliest=-32m@m latest=-2m@m \
+    | stats count, latest(_time) as _time, latest(type) as type, values(src_ip) as src_ip, values(suser) as user by host, dhost \
+    | where type=="Event::Endpoint::SavDisabled" \
+    | eval cyences_severity = "high" ] \
 | sort -count \
 | `cs_human_readable_time_format(_time, event_time)` \
 | `cs_sophos_realtime_protection_disabled_filter`
@@ -2995,7 +3003,7 @@ request.ui_dispatch_app = cyences_app_for_splunk
 request.ui_dispatch_view = search
 search = `cs_sophos` type IN ("Event::Endpoint::Threat::CleanupFailed", "Event::Endpoint::CoreCleanFailed", "Event::Endpoint::CoreHmpaCleanFailed", "Event::Endpoint::CoreSystemCleanFailed") \
 | stats count, latest(_time) as _time, values(name) as threat, values(src_ip) as src_ip, values(suser) as user by host, dhost | sort -count \
-| eval cyences_severity = "high" \
+| eval cyences_severity = "critical" \
 | `cs_human_readable_time_format(_time, event_time)` \
 | `cs_sophos_failed_to_cleanup_threat_filter`
 action.cyences_notable_event_action = 1


### PR DESCRIPTION
- Updated the severity of "Sophos RealTime Protection Disabled" to critical if it stayed disabled for more than 3 hrs.
- Updated the severity of "Failed to clean up threat by Sophos" alert to critical.