### PR TITLE
Added the device invetory related savedsearches

### DIFF
--- a/cyences_app_for_splunk/bin/cyences_device_manager.py
+++ b/cyences_app_for_splunk/bin/cyences_device_manager.py
@@ -15,7 +15,7 @@ logger = logger_manager.setup_logging("device_manager_v2", logging.INFO)
 
 IS_DEBUGGING_MODE = False
 CY_HOSTNAME_POSTFIXES_MACRO = "cs_device_inventory_hostname_postfixes"
-DEVICE_INVENTORY_LOOKUP_COLLECTION = "cs_device_inventory_collection_test"
+DEVICE_INVENTORY_LOOKUP_COLLECTION = "cs_device_inventory_collection_v2"
 
 MONTH_IN_SECOND = 60 * 60 * 24 * 30.5
 YEAR_IN_SECOND = MONTH_IN_SECOND * 12

--- a/cyences_app_for_splunk/bin/device_inventory_v2_util.py
+++ b/cyences_app_for_splunk/bin/device_inventory_v2_util.py
@@ -487,8 +487,8 @@ class DeviceManager:
 
             for product_uuid, entry_details in product_items.items():
                 if (
-                    int(entry_details["time"]) < min_time
-                    or int(entry_details["time"]) > max_time
+                    int(float(entry_details["time"])) < min_time
+                    or int(float(entry_details["time"])) > max_time
                 ):
                     self._remove_entry_content(
                         product_name, product_uuid, entry_details, device

--- a/cyences_app_for_splunk/default/collections.conf
+++ b/cyences_app_for_splunk/default/collections.conf
@@ -47,6 +47,27 @@ accelerated_fields.incident_id = {"notable_event_id": 1}
 
 [cs_kaspersky_inventory_collection]
 
+
+# Device Inventory v2
+[cs_device_inventory_collection_test]
+
+[cs_lansweeper_inventory_collection_test]
+
+[cs_tenable_inventory_collection_test]
+
+[cs_tenable_vuln_collection_test]
+
+[cs_qualys_inventory_collection_test]
+
+[cs_sophos_inventory_collection_test]
+
+[cs_windows_defender_inventory_collection_test]
+
+[cs_crowdstrike_inventory_collection_test]
+
+[cs_kaspersky_inventory_collection_test]
+
+
 # Microsoft Windows AD Objects
 [cs_ad_obj_domain_kv]
 enforceTypes = false

--- a/cyences_app_for_splunk/default/collections.conf
+++ b/cyences_app_for_splunk/default/collections.conf
@@ -49,23 +49,23 @@ accelerated_fields.incident_id = {"notable_event_id": 1}
 
 
 # Device Inventory v2
-[cs_device_inventory_collection_test]
+[cs_device_inventory_collection_v2]
 
-[cs_lansweeper_inventory_collection_test]
+[cs_lansweeper_inventory_collection_v2]
 
-[cs_tenable_inventory_collection_test]
+[cs_tenable_inventory_collection_v2]
 
-[cs_tenable_vuln_collection_test]
+[cs_tenable_vuln_collection_v2]
 
-[cs_qualys_inventory_collection_test]
+[cs_qualys_inventory_collection_v2]
 
-[cs_sophos_inventory_collection_test]
+[cs_sophos_inventory_collection_v2]
 
-[cs_windows_defender_inventory_collection_test]
+[cs_windows_defender_inventory_collection_v2]
 
-[cs_crowdstrike_inventory_collection_test]
+[cs_crowdstrike_inventory_collection_v2]
 
-[cs_kaspersky_inventory_collection_test]
+[cs_kaspersky_inventory_collection_v2]
 
 
 # Microsoft Windows AD Objects

--- a/cyences_app_for_splunk/default/macros.conf
+++ b/cyences_app_for_splunk/default/macros.conf
@@ -199,10 +199,10 @@ definition = dedup host \
 | table time, product_name, product_uuid, windows_defender_host, hostname, ip, mac_address, RTP_state, Platform_version, Engine_version, AVSignature_version, BM_state, IOAV_state, OA_state, Last_full_scan_start_time, Last_full_scan_end_time, Last_quick_scan_start_time, Last_quick_scan_end_time \
 | cyencesdevicemanager operation="addentries" \
 | append \
-    [| inputlookup cs_windows_defender_inventory_test ] \
+    [| inputlookup cs_windows_defender_inventory_v2 ] \
 | stats latest(time) as time, latest(*) as * by windows_defender_host \
 | eval _key=windows_defender_host \
-| outputlookup cs_windows_defender_inventory_test
+| outputlookup cs_windows_defender_inventory_v2
 # | `cs_device_inventory_out_to_temp_lookup`
 
 

--- a/cyences_app_for_splunk/default/macros.conf
+++ b/cyences_app_for_splunk/default/macros.conf
@@ -194,13 +194,16 @@ iseval = 0
 
 [cs_windows_defender_inventory_fill_search]
 definition = dedup host \
-| eval hostname=lower(host), ip="", mac_address="", Last_full_scan_start_time=if(Last_full_scan_start_time="1/1/1601 12:00:00 AM", "-", Last_full_scan_start_time), Last_full_scan_end_time=if(Last_full_scan_end_time="1/1/1601 12:00:00 AM", "-", Last_full_scan_end_time),  Last_quick_scan_start_time=if(Last_quick_scan_start_time="1/1/1601 12:00:00 AM", "-", Last_quick_scan_start_time), Last_quick_scan_end_time=if(Last_quick_scan_end_time="1/1/1601 12:00:00 AM", "-", Last_quick_scan_end_time) \
+| eval hostname=lower(host), ip="", mac_address="", product_name="Windows Defender", product_uuid=host, Last_full_scan_start_time=if(Last_full_scan_start_time="1/1/1601 12:00:00 AM", "-", Last_full_scan_start_time), Last_full_scan_end_time=if(Last_full_scan_end_time="1/1/1601 12:00:00 AM", "-", Last_full_scan_end_time), Last_quick_scan_start_time=if(Last_quick_scan_start_time="1/1/1601 12:00:00 AM", "-", Last_quick_scan_start_time), Last_quick_scan_end_time=if(Last_quick_scan_end_time="1/1/1601 12:00:00 AM", "-", Last_quick_scan_end_time), time=_time \
 | rename host as windows_defender_host \
-| table _time, windows_defender_host, hostname, ip, mac_address, RTP_state, Platform_version, Engine_version, AVSignature_version, BM_state, IOAV_state, OA_state, Last_full_scan_start_time, Last_full_scan_end_time, Last_quick_scan_start_time, Last_quick_scan_end_time \
-| append [| inputlookup cs_windows_defender_inventory | rename time as _time] \
-| stats latest(_time) as time, latest(*) as * by windows_defender_host \
-| eval _key=windows_defender_host | outputlookup cs_windows_defender_inventory \
-| `cs_device_inventory_out_to_temp_lookup`
+| table time, product_name, product_uuid, windows_defender_host, hostname, ip, mac_address, RTP_state, Platform_version, Engine_version, AVSignature_version, BM_state, IOAV_state, OA_state, Last_full_scan_start_time, Last_full_scan_end_time, Last_quick_scan_start_time, Last_quick_scan_end_time \
+| cyencesdevicemanager operation="addentries" \
+| append \
+    [| inputlookup cs_windows_defender_inventory_test ] \
+| stats latest(time) as time, latest(*) as * by windows_defender_host \
+| eval _key=windows_defender_host \
+| outputlookup cs_windows_defender_inventory_test
+# | `cs_device_inventory_out_to_temp_lookup`
 
 
 

--- a/cyences_app_for_splunk/default/savedsearches.conf
+++ b/cyences_app_for_splunk/default/savedsearches.conf
@@ -3501,6 +3501,314 @@ search = | inputlookup cs_device_inventory \
 
 
 
+
+# ====================
+# Device Inventory V2
+# ====================
+
+
+[Device Inventory - Lansweeper - V2]
+disabled = 0
+enableSched = 1
+alert.track = 0
+cron_schedule = 0 * * * *
+description = This report update the device inventory every hour and generates lookup for lansweeper data. \
+\
+Data Collection - The lansweeper data needs to be collected via the Lansweeper Add-On for Splunk(https://splunkbase.splunk.com/app/5418/).
+dispatch.earliest_time = -62m@m
+dispatch.latest_time = -2m@m
+# This time-range does not apply in the search as it is given as part of search-query
+display.general.type = statistics
+display.page.search.tab = statistics
+display.page.search.mode = fast
+request.ui_dispatch_app = cyences_app_for_splunk
+request.ui_dispatch_view = search
+search = `cs_lansweeper` `cs_lansweeper_timerange` \
+| dedup id \
+| eval product_name="Lansweeper", product_uuid=id, hostname=mvdedup(mvappend(AssetName, FQDN)), ip=lower(IPAddress), mac_address=lower(Mac), antivirus=mvzip(antivirus_name, antivirus_enabled, "#") \
+| rename _time as time, id as lansweeper_id, host as lansweeper_collected_by, site_name as Site, AssetTypename as AssetType, Statename as lansweeper_state, Userdomain as Domain, AssetGroup as GroupName, OScode as OSVersion, Username as lansweeper_user, version as AssetVersion, OS as lansweeper_os, FQDN as lansweeper_fqdn, Firstseen as FirstSeen, Lastseen as LastSeen \
+| table time, product_name, product_uuid, ip, mac_address, lansweeper_id, hostname, lansweeper_collected_by, Site, AssetType, lansweeper_state, Domain, GroupName, OSVersion, BuildNumber, AssetVersion, lansweeper_user, lansweeper_os, Description, IPLocation, lansweeper_fqdn, antivirus, AssetDomain, FirstSeen, LastSeen, AssetName, Serialnumber, Processor, Model, Manufacturer, OSRelease, OSname, SystemVersion, Memory, LsAgentVersion, LastLsAgent, LastChanged, DNSName \
+| cyencesdevicemanager operation="addentries" \
+| stats values(GroupName) as GroupName, values(antivirus) as antivirus, values(Processor) as Processor, first(*) as * by lansweeper_id \
+| eval _key=lansweeper_id \
+| outputlookup cs_lansweeper_inventory_test
+# Note - We are not appending previous lookup in case of Lansweeper as Lansweeper Add-on always fetch full asset list.
+action.cyences_notable_event_action.products = Lansweeper
+
+
+[Device Inventory - Tenable - V2]
+disabled = 0
+enableSched = 1
+alert.track = 0
+cron_schedule = 2 * * * *
+description = This report update the device inventory every hour and generates lookup for tenable data. \
+\
+Data Collection - The tenable data (asset summaries) needs to be collected via the Tenable Add-On for Splunk(https://splunkbase.splunk.com/app/4060/).
+dispatch.earliest_time = -62m@m
+dispatch.latest_time = -2m@m
+display.general.type = statistics
+display.page.search.tab = statistics
+display.page.search.mode = fast
+request.ui_dispatch_app = cyences_app_for_splunk
+request.ui_dispatch_view = search
+search = `cs_tenable_assets` | dedup tenable_uuid \
+| eval tenable_fqdn=mvjoin(mvappend(fqdns, dnsName), ", "), tenable_netbios=mvjoin(mvappend(netbios_names, biosGUID), ", "), tenable_os=mvjoin(operating_systems, ", "), time=_time, product_name="Tenable", product_uuid=tenable_uuid, ip=mvdedup(mvappend(ip, ipv4s, ipv6s)), mac_address=mvdedup(mvappend(mac_address, mac_addresses, macAddress)), hostname=mvappend(hostnames, fqdns, dnsName, dns_name) \
+| rename host as tenable_collected_by, network_name as tenable_network_name, state as tenable_state \
+| table time, product_name, product_uuid, ip, mac_address, hostname, tenable_collected_by, tenable_fqdn, tenable_netbios, tenable_os, tenable_state, tenable_network_name, created_at, first_scan_time, first_seen, has_agent, has_plugin_results, last_authenticated_scan_date, last_licensed_scan_date, last_seen, tenable_uuid \
+| cyencesdevicemanager operation="addentries" \
+| append [| inputlookup cs_tenable_inventory_test] \
+| stats latest(time) as time, latest(*) as * by tenable_uuid \
+| eval _key=tenable_uuid | outputlookup cs_tenable_inventory_test
+action.cyences_notable_event_action.products = Tenable
+
+
+[Device Inventory - Tenable Vuln - V2]
+disabled = 0
+enableSched = 1
+alert.track = 0
+cron_schedule = 59 * * * *
+description = This report generate tenable vulnerabilities lookup. \
+\
+Data Collection - The tenable data are necessary to collect the vulnerability scan results and host summaries via the Tenable Add-On for Splunk(https://splunkbase.splunk.com/app/4060/).
+dispatch.earliest_time = -62m@m
+dispatch.latest_time = -2m@m
+display.general.type = statistics
+display.page.search.tab = statistics
+display.page.search.mode = fast
+request.ui_dispatch_app = cyences_app_for_splunk
+request.ui_dispatch_view = search
+search = `cs_tenable_vuln` | dedup tenable_uuid, vul_id \
+| eval time=_time, product_name="Tenable", product_uuid=tenable_uuid \
+| fillnull ip, hostname, mac_address value="" \
+| table time, product_name, product_uuid, hostname, ip, mac_address, tenable_uuid, vul_id, vul_name, vul_description, vul_severity, vul_severity_id, vul_state, last_fixed, last_found, vul_cve, vul_solution, vul_cpe, vul_family, vul_has_patch, vul_in_the_news, vul_risk_factor, vul_synopsis, vul_type, vul_version, vul_protocol, vul_port \
+| cyencesdevicemanager operation="addentries" \
+| append [| inputlookup cs_tenable_vuln_test] \
+| dedup tenable_uuid, vul_id sortby -time \
+| outputlookup cs_tenable_vuln_test
+action.cyences_notable_event_action.products = Tenable
+
+
+[Device Inventory - Qualys - V2]
+disabled = 0
+enableSched = 1
+alert.track = 0
+cron_schedule = 4 * * * *
+description = This report update the device inventory every hour and generates lookup for qualys data. \
+\
+Data Collection - The qualys data (host summaries) needs to be collected via the Qualys Technology Add-on (TA) for Splunk(https://splunkbase.splunk.com/app/2964/).
+dispatch.earliest_time = -62m@m
+dispatch.latest_time = -2m@m
+display.general.type = statistics
+display.page.search.tab = statistics
+display.page.search.mode = fast
+request.ui_dispatch_app = cyences_app_for_splunk
+request.ui_dispatch_view = search
+search = `cs_qualys_hostsummary` | dedup HOST_ID \
+| eval time=_time, product_name="Qualys", product_uuid=HOST_ID, ip=lower(IP), hostname=lower(DNS), mac_address="" \
+| fillnull hostname value="" \
+| rename HOST_ID as qualys_id, host as qualys_collected_by, OS as QUALYS_OS, DNS as qualys_dns \
+| table time, product_name, product_uuid, ip, mac_address, hostname, qualys_collected_by, qualys_id, qualys_dns, QUALYS_OS, NETWORK_ID, TRACKING_METHOD, ACTIVE*, CONFIRMED*, FIXED*, INFO*, LAST_*, NEW*, POTENTIAL*, RE_OPENED*, SEVERITY_*, TOTAL_VULNS \
+| cyencesdevicemanager operation="addentries" \
+| append [| inputlookup cs_qualys_inventory_test] \
+| stats latest(time) as time, latest(*) as * by qualys_id \
+| eval _key=qualys_id | outputlookup cs_qualys_inventory_test
+action.cyences_notable_event_action.products = Qualys
+
+
+[Device Inventory - Sophos - V2]
+disabled = 0
+enableSched = 1
+alert.track = 0
+cron_schedule = 6 * * * *
+description = This report update the device inventory every hour and generates lookup for sophos data. \
+\
+Data Collection - The sophos data are collected via custom command available withing the App via REST API call to Sophos Central. (See Sophos documentation for more information.)
+dispatch.earliest_time = -62m@m
+dispatch.latest_time = -2m@m
+display.general.type = statistics
+display.page.search.tab = statistics
+display.page.search.mode = fast
+request.ui_dispatch_app = cyences_app_for_splunk
+request.ui_dispatch_view = search
+search = | sophosinstancedetails all_endpoints=True | extract \
+| rename id as sophos_uuid, "tenant.id" as sophos_customer_id, type as sophos_type, "health.overall" as sophos_health, "health.threats.status" as sophos_threats_status, "health.services.status" as sophos_services_status, "lockdown.status" as sophos_lockdown_status, "lockdown.updateStatus" as sophos_lockdown_update_status, "associatedPerson.name" as sophos_user, "associatedPerson.viaLogin" as sophos_login_via, "os.name" as sophos_os | fillnull "os.build", "os.isServer", "os.majorVersion", "os.minorVersion", "os.platform" value="-" \
+| eval sophos_os_details = mvappend("Platform:".'os.platform', "Build No.: ".'os.build', "ServerOS:".'os.isServer', "OS MajorVersion:".'os.majorVersion', "OS MinorVersion:".'os.minorVersion') \
+| eval service_status=mvzip('health.services.serviceDetails{}.name', 'health.services.serviceDetails{}.status') \
+| eval sophos_product_installed=mvzip('assignedProducts{}.code', mvzip('assignedProducts{}.status', 'assignedProducts{}.version')) \
+| eval time=strptime(lastSeenAt, "%FT%T.%3QZ"), product_name="Sophos", product_uuid=sophos_uuid, ip=lower(mvdedup(mvappend('ipv4Addresses{}','ipv6Addresses{}'))), hostname=lower(hostname), mac_address=lower('macAddresses{}') \
+| table time, product_name, product_uuid, sophos_customer_id, sophos_uuid, ip, hostname, mac_address, sophos_os, sophos_os_details, sophos_user, sophos_login_via, tamperProtectionEnabled, service_status, sophos_product_installed, sophos_health, sophos_services_status, sophos_threats_status, sophos_lockdown_status, sophos_lockdown_update_status, sophos_type \
+| cyencesdevicemanager operation="addentries" \
+| eval _key=sophos_uuid | outputlookup cs_sophos_inventory_test
+# Note - We are not appending previous lookup in case of Sophos as custom command for Sophos data fetch always fetch complete asset list.
+action.cyences_notable_event_action.products = Sophos
+
+
+[Device Inventory - Windows Defender - V2]
+disabled = 0
+enableSched = 1
+alert.track = 0
+cron_schedule = 8 * * * *
+description = This report update the device inventory every hour and generates lookup for windows defender data. \
+\
+Data Collection - The windows defender data needs to be collected via the Windows Defender Add-on (https://splunkbase.splunk.com/app/3734/).
+dispatch.earliest_time = -62m@m
+dispatch.latest_time = -2m@m
+display.general.type = statistics
+display.page.search.tab = statistics
+display.page.search.mode = fast
+request.ui_dispatch_app = cyences_app_for_splunk
+request.ui_dispatch_view = search
+search = `cs_windows_defender` EventCode=1151 | `cs_windows_defender_inventory_fill_search`
+action.cyences_notable_event_action.products = Windows Defender
+
+
+[Device Inventory - CrowdStrike - V2]
+disabled = 0
+enableSched = 1
+alert.track = 0
+cron_schedule = 10 * * * *
+description = This report update the device inventory every hour and generates lookup for crowdstrike data. \
+\
+Data Collection - The crowdstrike data needs to be collected via the CrowdStrike Event Stream Add-on (https://splunkbase.splunk.com/app/5082/).
+dispatch.earliest_time = -62m@m
+dispatch.latest_time = -2m@m
+display.general.type = statistics
+display.page.search.tab = statistics
+display.page.search.mode = fast
+request.ui_dispatch_app = cyences_app_for_splunk
+request.ui_dispatch_view = search
+search = `cs_crowdstrike_eventstream` | eval crowdstrike_userid=coalesce('event.UserId', 'event.UserName', user) | dedup crowdstrike_userid \
+| eval ip=lower(coalesce('event.UserIp', 'event.LocalIP', src)), hostname=lower(coalesce('event.ComputerName', 'event.HostnameField')), time=_time, product_name="CrowdStrike", product_uuid=crowdstrike_userid \
+| rename host as crowdstrike_collected_by, "metadata.customerIDString" as crowdstrike_customer_id, "event.MACAddress" as mac_address \
+| fillnull ip, hostname, mac_address value="" \
+| table time, product_name, product_uuid, crowdstrike_collected_by, crowdstrike_customer_id, ip, hostname, mac_address, crowdstrike_userid \
+| cyencesdevicemanager operation="addentries" \
+| append [| inputlookup cs_crowdstrike_inventory_test ] \
+| stats latest(time) as time, latest(*) as * by crowdstrike_userid \
+| eval _key=crowdstrike_userid | outputlookup cs_crowdstrike_inventory_test
+action.cyences_notable_event_action.products = CrowdStrike EventStream
+
+
+[Device Inventory - Kaspersky - V2]
+disabled = 0
+enableSched = 1
+alert.track = 0
+cron_schedule = 12 * * * *
+description = This report update the device inventory every hour and generates lookup for Kaspersky data. \
+\
+Data Collection - The Kaspersky data needs to be collected via the Kaspersky Add-on for Splunk (https://splunkbase.splunk.com/app/4656/#/details).
+dispatch.earliest_time = -62m@m
+dispatch.latest_time = -2m@m
+display.general.type = statistics
+display.page.search.tab = statistics
+display.page.search.mode = fast
+request.ui_dispatch_app = cyences_app_for_splunk
+request.ui_dispatch_view = search
+search = `cs_kaspersky` ProductName=KES*  \
+| rename dst as ip , dest as hostname,  ProductName as kaspersky_collected_by , ProductVersion as kaspersky_version, macaddress as mac_address  \
+| eval hostname=lower(hostname) \
+| table _time, ip, hostname, mac_address, kaspersky_collected_by, kaspersky_version   \
+| fillnull ip, hostname, mac_address value=""  \
+| stats latest(_time) as _time latest(*) as * by hostname \
+| join type=left [| search `cs_kaspersky`  log_type=KLSRV_HOST_STATUS_CRITICAL "Protection is disabled" \
+    | rex field=_raw "Status of device \'(?<critical_device>[^\']*)" \
+    | stats latest(_time) as time  by critical_device \
+    | rename critical_device as hostname \
+    |  eval hostname=lower(hostname) ]  \
+| eval kaspersky_status=if(_time<time AND isnotnull(time),"Disabled","Present")  | fields - time \
+| eval product_name="Kaspersky", product_uuid=hostname, time=_time \
+| cyencesdevicemanager operation="addentries" \
+| append [|inputlookup cs_kaspersky_inventory_test ] \
+| stats latest(*) as * latest(time) as time by hostname \
+| eval _key=hostname \
+| eval kaspersky_host=hostname \
+| outputlookup cs_kaspersky_inventory_test
+action.cyences_notable_event_action.products = Kaspersky
+
+
+# Backfill
+[Device Inventory Backfill - V2]
+disabled = 0
+enableSched = 0
+alert.track = 0
+run_on_startup = true
+description = This report backfills the all device inventory lookups. (Default timerange: last 30 days). \
+The report executes on Splunk start to make sure we do not miss data as well as this make sure user do not have make manually tasks.
+dispatch.earliest_time = -30d@d
+dispatch.latest_time = now
+display.general.type = statistics
+display.page.search.tab = statistics
+display.page.search.mode = fast
+request.ui_dispatch_app = cyences_app_for_splunk
+request.ui_dispatch_view = search
+search = | savedsearch "Device Inventory - Tenable Vuln - V2" | where SEARCHNOTHING="SEARCHNOTHING" \
+| append [| savedsearch "Device Inventory - Lansweeper - V2" | where SEARCHNOTHING="SEARCHNOTHING"] \
+| append [| savedsearch "Device Inventory - Tenable - V2" | where SEARCHNOTHING="SEARCHNOTHING"] \
+| append [| savedsearch "Device Inventory - Qualys - V2" | where SEARCHNOTHING="SEARCHNOTHING"] \
+| append [| savedsearch "Device Inventory - Sophos - V2" | where SEARCHNOTHING="SEARCHNOTHING"] \
+| append [| search `cs_windows_defender` EventCode=1151 `cs_windows_defender_max_timerange` | `cs_windows_defender_inventory_fill_search` | where SEARCHNOTHING="SEARCHNOTHING"] \
+| append [| savedsearch "Device Inventory - CrowdStrike - V2" | where SEARCHNOTHING="SEARCHNOTHING"] \
+| append [| savedsearch "Device Inventory - Kaspersky - V2" | where SEARCHNOTHING="SEARCHNOTHING"]
+
+
+[Device Inventory Lookup CleanUp - V2]
+disabled = 0
+enableSched = 1
+alert.track = 0
+cron_schedule = 0 5 * * 0
+description = This report cleans up device inventory lookup every week (sunday early morning) and removes the devices from the inventories which did not showup in last 60 days.
+dispatch.earliest_time = -60d@d
+dispatch.latest_time = now
+display.general.type = statistics
+display.page.search.tab = statistics
+display.page.search.mode = fast
+request.ui_dispatch_app = cyences_app_for_splunk
+request.ui_dispatch_view = search
+search = | inputlookup cs_device_inventory_merge_logs.csv \
+| addinfo | where indextime>=info_min_time and indextime<=info_max_time \
+| outputlookup cs_device_inventory_merge_logs.csv | where SEARCHNOTHING="SEARCHNOTHING" \
+| append [| inputlookup cs_tenable_inventory_test \
+| addinfo | where time>=info_min_time and time<=info_max_time \
+| outputlookup cs_tenable_inventory_test | where SEARCHNOTHING="SEARCHNOTHING"] \
+| append [| inputlookup cs_qualys_inventory_test \
+| addinfo | where time>=info_min_time and time<=info_max_time \
+| outputlookup cs_qualys_inventory_test | where SEARCHNOTHING="SEARCHNOTHING"] \
+| append [| inputlookup cs_windows_defender_inventory_test \
+| addinfo | where time>=info_min_time and time<=info_max_time \
+| outputlookup cs_windows_defender_inventory_test | where SEARCHNOTHING="SEARCHNOTHING"] \
+| append [| inputlookup cs_crowdstrike_inventory_test \
+| addinfo | where time>=info_min_time and time<=info_max_time \
+| outputlookup cs_crowdstrike_inventory_test | where SEARCHNOTHING="SEARCHNOTHING"] \
+| append [| inputlookup cs_kaspersky_inventory_test \
+| addinfo | where time>=info_min_time and time<=info_max_time \
+| outputlookup cs_kaspersky_inventory_test | where SEARCHNOTHING="SEARCHNOTHING"] \
+| append [ | makeresults count=1 | addinfo \
+| map search="| cyencesdevicemanager operation=\"cleanup\" mintime=$info_min_time$ maxtime=$info_max_time$" \
+| where SEARCHNOTHING="SEARCHNOTHING"] \
+| appendpipe [| inputlookup cs_tenable_vuln_test \
+| join tenable_uuid [| inputlookup cs_device_inventory_test | search tenable_uuid=* | mvexpand tenable_uuid | fields tenable_uuid, uuid | table tenable_uuid, uuid] \
+| search uuid=* | fields - uuid \
+| outputlookup cs_tenable_vuln_test | where SEARCHNOTHING="SEARCHNOTHING"]
+# Note - Sophos and Lansweeper Cleanup are not required as those lookups are always overridden completely.
+
+
+# Merging
+[Device Inventory Merge Similar Devices - V2]
+disabled = 0
+enableSched = 1
+alert.track = 0
+cron_schedule = 15 0 * * *
+description = This report merges the similar devices every day (at early midnight)
+dispatch.earliest_time = -60d@d
+dispatch.latest_time = now
+display.general.type = statistics
+display.page.search.tab = statistics
+display.page.search.mode = fast
+request.ui_dispatch_app = cyences_app_for_splunk
+request.ui_dispatch_view = search
+search = | cyencesdevicemanager operation="merge" | table *
+
+
 # ===============
 # Authentication
 # ===============

--- a/cyences_app_for_splunk/default/savedsearches.conf
+++ b/cyences_app_for_splunk/default/savedsearches.conf
@@ -3531,8 +3531,8 @@ search = `cs_lansweeper` `cs_lansweeper_timerange` \
 | cyencesdevicemanager operation="addentries" \
 | stats values(GroupName) as GroupName, values(antivirus) as antivirus, values(Processor) as Processor, first(*) as * by lansweeper_id \
 | eval _key=lansweeper_id \
-| outputlookup cs_lansweeper_inventory_test
-# Note - We are not appending previous lookup in case of Lansweeper as Lansweeper Add-on always fetch full asset list.
+| outputlookup cs_lansweeper_inventory_v2 \
+``` Note - We are not appending previous lookup in case of Lansweeper as Lansweeper Add-on always fetch full asset list.```
 action.cyences_notable_event_action.products = Lansweeper
 
 
@@ -3556,9 +3556,9 @@ search = `cs_tenable_assets` | dedup tenable_uuid \
 | rename host as tenable_collected_by, network_name as tenable_network_name, state as tenable_state \
 | table time, product_name, product_uuid, ip, mac_address, hostname, tenable_collected_by, tenable_fqdn, tenable_netbios, tenable_os, tenable_state, tenable_network_name, created_at, first_scan_time, first_seen, has_agent, has_plugin_results, last_authenticated_scan_date, last_licensed_scan_date, last_seen, tenable_uuid \
 | cyencesdevicemanager operation="addentries" \
-| append [| inputlookup cs_tenable_inventory_test] \
+| append [| inputlookup cs_tenable_inventory_v2] \
 | stats latest(time) as time, latest(*) as * by tenable_uuid \
-| eval _key=tenable_uuid | outputlookup cs_tenable_inventory_test
+| eval _key=tenable_uuid | outputlookup cs_tenable_inventory_v2
 action.cyences_notable_event_action.products = Tenable
 
 
@@ -3582,9 +3582,9 @@ search = `cs_tenable_vuln` | dedup tenable_uuid, vul_id \
 | fillnull ip, hostname, mac_address value="" \
 | table time, product_name, product_uuid, hostname, ip, mac_address, tenable_uuid, vul_id, vul_name, vul_description, vul_severity, vul_severity_id, vul_state, last_fixed, last_found, vul_cve, vul_solution, vul_cpe, vul_family, vul_has_patch, vul_in_the_news, vul_risk_factor, vul_synopsis, vul_type, vul_version, vul_protocol, vul_port \
 | cyencesdevicemanager operation="addentries" \
-| append [| inputlookup cs_tenable_vuln_test] \
+| append [| inputlookup cs_tenable_vuln_v2] \
 | dedup tenable_uuid, vul_id sortby -time \
-| outputlookup cs_tenable_vuln_test
+| outputlookup cs_tenable_vuln_v2
 action.cyences_notable_event_action.products = Tenable
 
 
@@ -3609,9 +3609,9 @@ search = `cs_qualys_hostsummary` | dedup HOST_ID \
 | rename HOST_ID as qualys_id, host as qualys_collected_by, OS as QUALYS_OS, DNS as qualys_dns \
 | table time, product_name, product_uuid, ip, mac_address, hostname, qualys_collected_by, qualys_id, qualys_dns, QUALYS_OS, NETWORK_ID, TRACKING_METHOD, ACTIVE*, CONFIRMED*, FIXED*, INFO*, LAST_*, NEW*, POTENTIAL*, RE_OPENED*, SEVERITY_*, TOTAL_VULNS \
 | cyencesdevicemanager operation="addentries" \
-| append [| inputlookup cs_qualys_inventory_test] \
+| append [| inputlookup cs_qualys_inventory_v2] \
 | stats latest(time) as time, latest(*) as * by qualys_id \
-| eval _key=qualys_id | outputlookup cs_qualys_inventory_test
+| eval _key=qualys_id | outputlookup cs_qualys_inventory_v2
 action.cyences_notable_event_action.products = Qualys
 
 
@@ -3638,8 +3638,8 @@ search = | sophosinstancedetails all_endpoints=True | extract \
 | eval time=strptime(lastSeenAt, "%FT%T.%3QZ"), product_name="Sophos", product_uuid=sophos_uuid, ip=lower(mvdedup(mvappend('ipv4Addresses{}','ipv6Addresses{}'))), hostname=lower(hostname), mac_address=lower('macAddresses{}') \
 | table time, product_name, product_uuid, sophos_customer_id, sophos_uuid, ip, hostname, mac_address, sophos_os, sophos_os_details, sophos_user, sophos_login_via, tamperProtectionEnabled, service_status, sophos_product_installed, sophos_health, sophos_services_status, sophos_threats_status, sophos_lockdown_status, sophos_lockdown_update_status, sophos_type \
 | cyencesdevicemanager operation="addentries" \
-| eval _key=sophos_uuid | outputlookup cs_sophos_inventory_test
-# Note - We are not appending previous lookup in case of Sophos as custom command for Sophos data fetch always fetch complete asset list.
+| eval _key=sophos_uuid | outputlookup cs_sophos_inventory_v2 \
+``` Note - We are not appending previous lookup in case of Sophos as custom command for Sophos data fetch always fetch complete asset list.```
 action.cyences_notable_event_action.products = Sophos
 
 
@@ -3683,9 +3683,9 @@ search = `cs_crowdstrike_eventstream` | eval crowdstrike_userid=coalesce('event.
 | fillnull ip, hostname, mac_address value="" \
 | table time, product_name, product_uuid, crowdstrike_collected_by, crowdstrike_customer_id, ip, hostname, mac_address, crowdstrike_userid \
 | cyencesdevicemanager operation="addentries" \
-| append [| inputlookup cs_crowdstrike_inventory_test ] \
+| append [| inputlookup cs_crowdstrike_inventory_v2 ] \
 | stats latest(time) as time, latest(*) as * by crowdstrike_userid \
-| eval _key=crowdstrike_userid | outputlookup cs_crowdstrike_inventory_test
+| eval _key=crowdstrike_userid | outputlookup cs_crowdstrike_inventory_v2
 action.cyences_notable_event_action.products = CrowdStrike EventStream
 
 
@@ -3718,11 +3718,11 @@ search = `cs_kaspersky` ProductName=KES*  \
 | eval kaspersky_status=if(_time<time AND isnotnull(time),"Disabled","Present")  | fields - time \
 | eval product_name="Kaspersky", product_uuid=hostname, time=_time \
 | cyencesdevicemanager operation="addentries" \
-| append [|inputlookup cs_kaspersky_inventory_test ] \
+| append [|inputlookup cs_kaspersky_inventory_v2 ] \
 | stats latest(*) as * latest(time) as time by hostname \
 | eval _key=hostname \
 | eval kaspersky_host=hostname \
-| outputlookup cs_kaspersky_inventory_test
+| outputlookup cs_kaspersky_inventory_v2
 action.cyences_notable_event_action.products = Kaspersky
 
 
@@ -3767,29 +3767,29 @@ request.ui_dispatch_view = search
 search = | inputlookup cs_device_inventory_merge_logs.csv \
 | addinfo | where indextime>=info_min_time and indextime<=info_max_time \
 | outputlookup cs_device_inventory_merge_logs.csv | where SEARCHNOTHING="SEARCHNOTHING" \
-| append [| inputlookup cs_tenable_inventory_test \
+| append [| inputlookup cs_tenable_inventory_v2 \
 | addinfo | where time>=info_min_time and time<=info_max_time \
-| outputlookup cs_tenable_inventory_test | where SEARCHNOTHING="SEARCHNOTHING"] \
-| append [| inputlookup cs_qualys_inventory_test \
+| outputlookup cs_tenable_inventory_v2 | where SEARCHNOTHING="SEARCHNOTHING"] \
+| append [| inputlookup cs_qualys_inventory_v2 \
 | addinfo | where time>=info_min_time and time<=info_max_time \
-| outputlookup cs_qualys_inventory_test | where SEARCHNOTHING="SEARCHNOTHING"] \
-| append [| inputlookup cs_windows_defender_inventory_test \
+| outputlookup cs_qualys_inventory_v2 | where SEARCHNOTHING="SEARCHNOTHING"] \
+| append [| inputlookup cs_windows_defender_inventory_v2 \
 | addinfo | where time>=info_min_time and time<=info_max_time \
-| outputlookup cs_windows_defender_inventory_test | where SEARCHNOTHING="SEARCHNOTHING"] \
-| append [| inputlookup cs_crowdstrike_inventory_test \
+| outputlookup cs_windows_defender_inventory_v2 | where SEARCHNOTHING="SEARCHNOTHING"] \
+| append [| inputlookup cs_crowdstrike_inventory_v2 \
 | addinfo | where time>=info_min_time and time<=info_max_time \
-| outputlookup cs_crowdstrike_inventory_test | where SEARCHNOTHING="SEARCHNOTHING"] \
-| append [| inputlookup cs_kaspersky_inventory_test \
+| outputlookup cs_crowdstrike_inventory_v2 | where SEARCHNOTHING="SEARCHNOTHING"] \
+| append [| inputlookup cs_kaspersky_inventory_v2 \
 | addinfo | where time>=info_min_time and time<=info_max_time \
-| outputlookup cs_kaspersky_inventory_test | where SEARCHNOTHING="SEARCHNOTHING"] \
+| outputlookup cs_kaspersky_inventory_v2 | where SEARCHNOTHING="SEARCHNOTHING"] \
 | append [ | makeresults count=1 | addinfo \
 | map search="| cyencesdevicemanager operation=\"cleanup\" mintime=$info_min_time$ maxtime=$info_max_time$" \
 | where SEARCHNOTHING="SEARCHNOTHING"] \
-| appendpipe [| inputlookup cs_tenable_vuln_test \
-| join tenable_uuid [| inputlookup cs_device_inventory_test | search tenable_uuid=* | mvexpand tenable_uuid | fields tenable_uuid, uuid | table tenable_uuid, uuid] \
+| appendpipe [| inputlookup cs_tenable_vuln_v2 \
+| join tenable_uuid [| inputlookup cs_device_inventory_v2 | search tenable_uuid=* | mvexpand tenable_uuid | fields tenable_uuid, uuid | table tenable_uuid, uuid] \
 | search uuid=* | fields - uuid \
-| outputlookup cs_tenable_vuln_test | where SEARCHNOTHING="SEARCHNOTHING"]
-# Note - Sophos and Lansweeper Cleanup are not required as those lookups are always overridden completely.
+| outputlookup cs_tenable_vuln_v2 | where SEARCHNOTHING="SEARCHNOTHING"] \
+```Note - Sophos and Lansweeper Cleanup are not required as those lookups are always overridden completely.```
 
 
 # Merging

--- a/cyences_app_for_splunk/default/transforms.conf
+++ b/cyences_app_for_splunk/default/transforms.conf
@@ -87,6 +87,53 @@ collection = cs_kaspersky_inventory_collection
 fields_list = _key, time, ip, hostname, kaspersky_collected_by, kaspersky_version, kaspersky_host, mac_address,kaspersky_status
 
 
+# Device Inventory V2
+[cs_device_inventory_test]
+external_type = kvstore
+collection = cs_device_inventory_collection_test
+fields_list = _key, uuid, product_info, product_names, product_uuids, ips, mac_addresses, hostnames
+
+[cs_lansweeper_inventory_test]
+external_type = kvstore
+collection = cs_lansweeper_inventory_collection_test
+fields_list = _key, time, product_name, product_uuid, lansweeper_collected_by, hostname, ip, mac_address, lansweeper_id, Site, AssetType, lansweeper_state, Domain, GroupName, OSVersion, BuildNumber, AssetVersion, lansweeper_user, lansweeper_os, Description, IPLocation, lansweeper_fqdn, antivirus, AssetDomain, FirstSeen, LastSeen, AssetName, Serialnumber, Processor, Model, Manufacturer, OSRelease, OSname, SystemVersion, Memory, LsAgentVersion, LastLsAgent, LastChanged, DNSName
+
+[cs_tenable_inventory_test]
+external_type = kvstore
+collection = cs_tenable_inventory_collection_test
+fields_list = _key, time, product_name, product_uuid, ip, hostname, mac_address, tenable_uuid, created_at, first_scan_time, first_seen, has_agent, has_plugin_results, last_authenticated_scan_date, last_licensed_scan_date, last_seen, tenable_collected_by, tenable_fqdn, tenable_netbios, tenable_network_name, tenable_os, tenable_state
+
+[cs_tenable_vuln_test]
+external_type = kvstore
+collection = cs_tenable_vuln_collection_test
+fields_list = _key, _time, tenable_uuid, vul_id, vul_name, vul_description, vul_severity, vul_severity_id, vul_state, last_fixed, last_found, vul_cve, vul_solution, vul_cpe, vul_family, vul_has_patch, vul_in_the_news, vul_risk_factor, vul_synopsis, vul_type, vul_version, vul_protocol, vul_port
+
+[cs_qualys_inventory_test]
+external_type = kvstore
+collection = cs_qualys_inventory_collection_test
+fields_list = _key, time, product_name, product_uuid, ip, hostname, mac_address, qualys_id, ACTIVE, ACTIVE_SEVERITY_1, ACTIVE_SEVERITY_2, ACTIVE_SEVERITY_3, ACTIVE_SEVERITY_4, ACTIVE_SEVERITY_5, CONFIRMED, CONFIRMED_ACTIVE, CONFIRMED_FIXED, CONFIRMED_NEW, CONFIRMED_RE_OPENED, CONFIRMED_SEVERITY_1, CONFIRMED_SEVERITY_2, CONFIRMED_SEVERITY_3, CONFIRMED_SEVERITY_4, CONFIRMED_SEVERITY_5, FIXED, FIXED_SEVERITY_1, FIXED_SEVERITY_2, FIXED_SEVERITY_3, FIXED_SEVERITY_4, FIXED_SEVERITY_5, INFO, INFO_SEVERITY_1, INFO_SEVERITY_2, INFO_SEVERITY_3, LAST_SCAN_DATETIME, LAST_VM_SCANNED_DATE, LAST_VM_SCANNED_DURATION, NETWORK_ID, NEW, NEW_SEVERITY_1, NEW_SEVERITY_2, NEW_SEVERITY_3, NEW_SEVERITY_4, NEW_SEVERITY_5, POTENTIAL, POTENTIAL_ACTIVE, POTENTIAL_FIXED, POTENTIAL_NEW, POTENTIAL_RE_OPENED, POTENTIAL_SEVERITY_1, POTENTIAL_SEVERITY_2, POTENTIAL_SEVERITY_3, POTENTIAL_SEVERITY_4, POTENTIAL_SEVERITY_5, QUALYS_OS, RE_OPENED, RE_OPENED_SEVERITY_1, RE_OPENED_SEVERITY_2, RE_OPENED_SEVERITY_3, RE_OPENED_SEVERITY_4, RE_OPENED_SEVERITY_5, SEVERITY_1, SEVERITY_2, SEVERITY_3, SEVERITY_4, SEVERITY_5, TOTAL_VULNS, TRACKING_METHOD, qualys_collected_by, qualys_dns
+
+[cs_sophos_inventory_test]
+external_type = kvstore
+collection = cs_sophos_inventory_collection_test
+fields_list = _key, time, product_name, product_uuid, ip, hostname, mac_address, sophos_uuid, service_status, sophos_customer_id, sophos_health, sophos_lockdown_status, sophos_lockdown_update_status, sophos_login_via, sophos_os, sophos_os_details, sophos_product_installed, sophos_services_status, sophos_threats_status, sophos_type, sophos_user, tamperProtectionEnabled
+
+[cs_windows_defender_inventory_test]
+external_type = kvstore
+collection = cs_windows_defender_inventory_collection_test
+fields_list = _key, time, product_name, product_uuid, ip, hostname, mac_address, windows_defender_host, AVSignature_version, BM_state, Engine_version, IOAV_state, Last_full_scan_end_time, Last_full_scan_start_time, Last_quick_scan_end_time, Last_quick_scan_start_time, OA_state, Platform_version, RTP_state
+
+[cs_crowdstrike_inventory_test]
+external_type = kvstore
+collection = cs_crowdstrike_inventory_collection_test
+fields_list = _key, time, product_name, product_uuid, ip, hostname, mac_address, crowdstrike_userid, crowdstrike_collected_by, crowdstrike_customer_id
+
+[cs_kaspersky_inventory_test]
+external_type = kvstore
+collection = cs_kaspersky_inventory_collection_test
+fields_list = _key, time, product_name, product_uuid, ip, hostname, kaspersky_collected_by, kaspersky_version, kaspersky_host, mac_address,kaspersky_status
+
+
 # Lookups for AD Objects
 [cs_ad_audit_change_event_codes]
 filename = cs_obj_change_eventcodes.csv

--- a/cyences_app_for_splunk/default/transforms.conf
+++ b/cyences_app_for_splunk/default/transforms.conf
@@ -88,49 +88,49 @@ fields_list = _key, time, ip, hostname, kaspersky_collected_by, kaspersky_versio
 
 
 # Device Inventory V2
-[cs_device_inventory_test]
+[cs_device_inventory_v2]
 external_type = kvstore
-collection = cs_device_inventory_collection_test
+collection = cs_device_inventory_collection_v2
 fields_list = _key, uuid, product_info, product_names, product_uuids, ips, mac_addresses, hostnames
 
-[cs_lansweeper_inventory_test]
+[cs_lansweeper_inventory_v2]
 external_type = kvstore
-collection = cs_lansweeper_inventory_collection_test
+collection = cs_lansweeper_inventory_collection_v2
 fields_list = _key, time, product_name, product_uuid, lansweeper_collected_by, hostname, ip, mac_address, lansweeper_id, Site, AssetType, lansweeper_state, Domain, GroupName, OSVersion, BuildNumber, AssetVersion, lansweeper_user, lansweeper_os, Description, IPLocation, lansweeper_fqdn, antivirus, AssetDomain, FirstSeen, LastSeen, AssetName, Serialnumber, Processor, Model, Manufacturer, OSRelease, OSname, SystemVersion, Memory, LsAgentVersion, LastLsAgent, LastChanged, DNSName
 
-[cs_tenable_inventory_test]
+[cs_tenable_inventory_v2]
 external_type = kvstore
-collection = cs_tenable_inventory_collection_test
+collection = cs_tenable_inventory_collection_v2
 fields_list = _key, time, product_name, product_uuid, ip, hostname, mac_address, tenable_uuid, created_at, first_scan_time, first_seen, has_agent, has_plugin_results, last_authenticated_scan_date, last_licensed_scan_date, last_seen, tenable_collected_by, tenable_fqdn, tenable_netbios, tenable_network_name, tenable_os, tenable_state
 
-[cs_tenable_vuln_test]
+[cs_tenable_vuln_v2]
 external_type = kvstore
-collection = cs_tenable_vuln_collection_test
+collection = cs_tenable_vuln_collection_v2
 fields_list = _key, _time, tenable_uuid, vul_id, vul_name, vul_description, vul_severity, vul_severity_id, vul_state, last_fixed, last_found, vul_cve, vul_solution, vul_cpe, vul_family, vul_has_patch, vul_in_the_news, vul_risk_factor, vul_synopsis, vul_type, vul_version, vul_protocol, vul_port
 
-[cs_qualys_inventory_test]
+[cs_qualys_inventory_v2]
 external_type = kvstore
-collection = cs_qualys_inventory_collection_test
+collection = cs_qualys_inventory_collection_v2
 fields_list = _key, time, product_name, product_uuid, ip, hostname, mac_address, qualys_id, ACTIVE, ACTIVE_SEVERITY_1, ACTIVE_SEVERITY_2, ACTIVE_SEVERITY_3, ACTIVE_SEVERITY_4, ACTIVE_SEVERITY_5, CONFIRMED, CONFIRMED_ACTIVE, CONFIRMED_FIXED, CONFIRMED_NEW, CONFIRMED_RE_OPENED, CONFIRMED_SEVERITY_1, CONFIRMED_SEVERITY_2, CONFIRMED_SEVERITY_3, CONFIRMED_SEVERITY_4, CONFIRMED_SEVERITY_5, FIXED, FIXED_SEVERITY_1, FIXED_SEVERITY_2, FIXED_SEVERITY_3, FIXED_SEVERITY_4, FIXED_SEVERITY_5, INFO, INFO_SEVERITY_1, INFO_SEVERITY_2, INFO_SEVERITY_3, LAST_SCAN_DATETIME, LAST_VM_SCANNED_DATE, LAST_VM_SCANNED_DURATION, NETWORK_ID, NEW, NEW_SEVERITY_1, NEW_SEVERITY_2, NEW_SEVERITY_3, NEW_SEVERITY_4, NEW_SEVERITY_5, POTENTIAL, POTENTIAL_ACTIVE, POTENTIAL_FIXED, POTENTIAL_NEW, POTENTIAL_RE_OPENED, POTENTIAL_SEVERITY_1, POTENTIAL_SEVERITY_2, POTENTIAL_SEVERITY_3, POTENTIAL_SEVERITY_4, POTENTIAL_SEVERITY_5, QUALYS_OS, RE_OPENED, RE_OPENED_SEVERITY_1, RE_OPENED_SEVERITY_2, RE_OPENED_SEVERITY_3, RE_OPENED_SEVERITY_4, RE_OPENED_SEVERITY_5, SEVERITY_1, SEVERITY_2, SEVERITY_3, SEVERITY_4, SEVERITY_5, TOTAL_VULNS, TRACKING_METHOD, qualys_collected_by, qualys_dns
 
-[cs_sophos_inventory_test]
+[cs_sophos_inventory_v2]
 external_type = kvstore
-collection = cs_sophos_inventory_collection_test
+collection = cs_sophos_inventory_collection_v2
 fields_list = _key, time, product_name, product_uuid, ip, hostname, mac_address, sophos_uuid, service_status, sophos_customer_id, sophos_health, sophos_lockdown_status, sophos_lockdown_update_status, sophos_login_via, sophos_os, sophos_os_details, sophos_product_installed, sophos_services_status, sophos_threats_status, sophos_type, sophos_user, tamperProtectionEnabled
 
-[cs_windows_defender_inventory_test]
+[cs_windows_defender_inventory_v2]
 external_type = kvstore
-collection = cs_windows_defender_inventory_collection_test
+collection = cs_windows_defender_inventory_collection_v2
 fields_list = _key, time, product_name, product_uuid, ip, hostname, mac_address, windows_defender_host, AVSignature_version, BM_state, Engine_version, IOAV_state, Last_full_scan_end_time, Last_full_scan_start_time, Last_quick_scan_end_time, Last_quick_scan_start_time, OA_state, Platform_version, RTP_state
 
-[cs_crowdstrike_inventory_test]
+[cs_crowdstrike_inventory_v2]
 external_type = kvstore
-collection = cs_crowdstrike_inventory_collection_test
+collection = cs_crowdstrike_inventory_collection_v2
 fields_list = _key, time, product_name, product_uuid, ip, hostname, mac_address, crowdstrike_userid, crowdstrike_collected_by, crowdstrike_customer_id
 
-[cs_kaspersky_inventory_test]
+[cs_kaspersky_inventory_v2]
 external_type = kvstore
-collection = cs_kaspersky_inventory_collection_test
+collection = cs_kaspersky_inventory_collection_v2
 fields_list = _key, time, product_name, product_uuid, ip, hostname, kaspersky_collected_by, kaspersky_version, kaspersky_host, mac_address,kaspersky_status
 
 


### PR DESCRIPTION
- Added the saved searches related to device inventory.
- Added the lookup for specific device and main lookup for all devices.

Note: The existing device inventory is kept as is for now. We'll remove it at the end and update the lookup names when convenient.