### PR TITLE
Added splunk internal devices as a product in device inventory dashboard

### DIFF
--- a/cyences_app_for_splunk/default/data/ui/views/cs_device_inventory_table.xml
+++ b/cyences_app_for_splunk/default/data/ui/views/cs_device_inventory_table.xml
@@ -28,8 +28,8 @@
   <search id="base_summary">
     <query>| cyencesdevicemanager operation="getdevices" 
 | table product_names 
-| stats count as Total, sum(eval(if(product_names="Lansweeper", 1, 0))) as Lansweeper, sum(eval(if(product_names="Splunk Internal", 1, 0))) as Splunk_Internal, sum(eval(if(product_names="Qualys", 1, 0))) as Qualys, sum(eval(if(product_names="Tenable", 1, 0))) as Tenable, sum(eval(if(product_names="Windows Defender", 1, 0))) as Defender, sum(eval(if((product_names="Sophos"), 1, 0))) as Sophos, sum(eval(if(product_names="CrowdStrike", 1, 0))) as CrowdStrike, sum(eval(if(product_names="Kaspersky", 1, 0))) as Kaspersky, sum(eval(if(((product_names="Lansweeper") AND (product_names="Splunk Internal") AND ((product_names="Qualys") OR (product_names="Tenable")) AND ((product_names="Windows Defender") OR (product_names="Sophos") OR (product_names="CrowdStrike") OR (product_names="Kaspersky"))), 1, 0))) as All, sum(eval(if(((product_names="Qualys") OR (product_names="Tenable")), 1, 0))) as Vulnerability_Scanner, sum(eval(if(((product_names="Windows Defender") OR (product_names="Sophos") OR (product_names="CrowdStrike")OR (product_names="Kaspersky")), 1, 0))) as Antivirus 
-| eval No_Lansweeper=Total-Lansweeper, No_Qualys=Total-Qualys, No_Tenable=Total-Tenable, No_Sophos=Total-Sophos, No_Defender=Total-Defender, No_CrowdStrike=Total-CrowdStrike, No_Kaspersky=Total-Kaspersky, No_Antivirus=Total-Antivirus, No_Vulnerability_Scanner=Total-Vulnerability_Scanner, No_Splunk_Internal=Total-Splunk_Internal</query>
+| stats count as Total, sum(eval(if(product_names="Lansweeper", 1, 0))) as Lansweeper, sum(eval(if(product_names="Splunk Internal", 1, 0))) as Splunk, sum(eval(if(product_names="Qualys", 1, 0))) as Qualys, sum(eval(if(product_names="Tenable", 1, 0))) as Tenable, sum(eval(if(product_names="Windows Defender", 1, 0))) as Defender, sum(eval(if((product_names="Sophos"), 1, 0))) as Sophos, sum(eval(if(product_names="CrowdStrike", 1, 0))) as CrowdStrike, sum(eval(if(product_names="Kaspersky", 1, 0))) as Kaspersky, sum(eval(if(((product_names="Lansweeper") AND (product_names="Splunk Internal") AND ((product_names="Qualys") OR (product_names="Tenable")) AND ((product_names="Windows Defender") OR (product_names="Sophos") OR (product_names="CrowdStrike") OR (product_names="Kaspersky"))), 1, 0))) as All, sum(eval(if(((product_names="Qualys") OR (product_names="Tenable")), 1, 0))) as Vulnerability_Scanner, sum(eval(if(((product_names="Windows Defender") OR (product_names="Sophos") OR (product_names="CrowdStrike")OR (product_names="Kaspersky")), 1, 0))) as Antivirus 
+| eval No_Lansweeper=Total-Lansweeper, No_Qualys=Total-Qualys, No_Tenable=Total-Tenable, No_Sophos=Total-Sophos, No_Defender=Total-Defender, No_CrowdStrike=Total-CrowdStrike, No_Kaspersky=Total-Kaspersky, No_Antivirus=Total-Antivirus, No_Vulnerability_Scanner=Total-Vulnerability_Scanner, No_Splunk=Total-Splunk</query>
     <earliest>0</earliest>
     <latest>now</latest>
   </search>
@@ -78,7 +78,7 @@
       <chart>
         <title>Number of Devices That Are Connected To A Specific Security Component</title>
         <search base="base_summary">
-          <query>| table Total, Lansweeper, Qualys, Tenable, Sophos, Defender, CrowdStrike, Kaspersky, Splunk_Internal</query>
+          <query>| table Total, Lansweeper, Qualys, Tenable, Sophos, Defender, CrowdStrike, Kaspersky, Splunk</query>
         </search>
         <option name="charting.chart">bar</option>
         <option name="charting.chart.showDataLabels">all</option>
@@ -106,7 +106,7 @@
           <condition match="$click.name2$ == &quot;Kaspersky&quot;">
             <set token="tkn_sp_filter">kaspersky_last_event=*</set>
           </condition>
-          <condition match="$click.name2$ == &quot;Splunk_Internal&quot;">
+          <condition match="$click.name2$ == &quot;Splunk&quot;">
             <set token="tkn_sp_filter">product_names="Splunk Internal"</set>
           </condition>
           <condition>
@@ -125,7 +125,7 @@
       <chart>
         <title>Number of Devices That Contain A Specific Security Component</title>
         <search base="base_summary">
-          <query>| table Total, All, Lansweeper, Vulnerability_Scanner, Antivirus, Splunk_Internal</query>
+          <query>| table Total, All, Lansweeper, Vulnerability_Scanner, Antivirus, Splunk</query>
         </search>
         <option name="charting.chart">bar</option>
         <option name="charting.chart.showDataLabels">all</option>
@@ -144,7 +144,7 @@
           <condition match="$click.name2$ == &quot;Antivirus&quot;">
             <set token="tkn_sp_filter">(sophos_last_event=* OR defender_last_event=* OR crowdstrike_last_event=* OR kaspersky_last_event=*)</set>
           </condition>
-          <condition match="$click.name2$ == &quot;Splunk_Internal&quot;">
+          <condition match="$click.name2$ == &quot;Splunk&quot;">
             <set token="tkn_sp_filter">product_names="Splunk Internal"</set>
           </condition>
           <condition>
@@ -161,7 +161,7 @@
       <chart>
         <title>Number of Devices That Lack A Specific Security Component</title>
         <search base="base_summary">
-          <query>| table Total, No_Lansweeper, No_Vulnerability_Scanner, No_Antivirus, No_Splunk_Internal</query>
+          <query>| table Total, No_Lansweeper, No_Vulnerability_Scanner, No_Antivirus, No_Splunk</query>
         </search>
         <option name="charting.chart">bar</option>
         <option name="charting.chart.showDataLabels">all</option>
@@ -177,7 +177,7 @@
           <condition match="$click.name2$ == &quot;No_Antivirus&quot;">
             <set token="tkn_sp_filter">NOT (sophos_last_event=* OR defender_last_event=* OR crowdstrike_last_event=* OR kaspersky_last_event=*)</set>
           </condition>
-          <condition match="$click.name2$ == &quot;No_Splunk_Internal&quot;">
+          <condition match="$click.name2$ == &quot;No_Splunk&quot;">
             <set token="tkn_sp_filter">NOT (product_names="Splunk Internal")</set>
           </condition>
           <condition>

--- a/cyences_app_for_splunk/default/data/ui/views/cs_device_inventory_table.xml
+++ b/cyences_app_for_splunk/default/data/ui/views/cs_device_inventory_table.xml
@@ -28,8 +28,8 @@
   <search id="base_summary">
     <query>| cyencesdevicemanager operation="getdevices" 
 | table product_names 
-| stats count as Total, sum(eval(if(product_names="Lansweeper", 1, 0))) as Lansweeper, sum(eval(if(product_names="Qualys", 1, 0))) as Qualys, sum(eval(if(product_names="Tenable", 1, 0))) as Tenable, sum(eval(if(product_names="Windows Defender", 1, 0))) as Defender, sum(eval(if((product_names="Sophos"), 1, 0))) as Sophos, sum(eval(if(product_names="CrowdStrike", 1, 0))) as CrowdStrike, sum(eval(if(product_names="Kaspersky", 1, 0))) as Kaspersky, sum(eval(if(((product_names="Lansweeper") AND ((product_names="Qualys") OR (product_names="Tenable")) AND ((product_names="Windows Defender") OR (product_names="Sophos") OR (product_names="CrowdStrike") OR (product_names="Kaspersky"))), 1, 0))) as All, sum(eval(if(((product_names="Qualys") OR (product_names="Tenable")), 1, 0))) as Vulnerability_Scanner, sum(eval(if(((product_names="Windows Defender") OR (product_names="Sophos") OR (product_names="CrowdStrike")OR (product_names="Kaspersky")), 1, 0))) as Antivirus 
-| eval No_Lansweeper=Total-Lansweeper, No_Qualys=Total-Qualys, No_Tenable=Total-Tenable, No_Sophos=Total-Sophos, No_Defender=Total-Defender, No_CrowdStrike=Total-CrowdStrike, No_Kaspersky=Total-Kaspersky, No_Antivirus=Total-Antivirus, No_Vulnerability_Scanner=Total-Vulnerability_Scanner</query>
+| stats count as Total, sum(eval(if(product_names="Lansweeper", 1, 0))) as Lansweeper, sum(eval(if(product_names="Splunk Internal", 1, 0))) as Splunk_Internal, sum(eval(if(product_names="Qualys", 1, 0))) as Qualys, sum(eval(if(product_names="Tenable", 1, 0))) as Tenable, sum(eval(if(product_names="Windows Defender", 1, 0))) as Defender, sum(eval(if((product_names="Sophos"), 1, 0))) as Sophos, sum(eval(if(product_names="CrowdStrike", 1, 0))) as CrowdStrike, sum(eval(if(product_names="Kaspersky", 1, 0))) as Kaspersky, sum(eval(if(((product_names="Lansweeper") AND (product_names="Splunk Internal") AND ((product_names="Qualys") OR (product_names="Tenable")) AND ((product_names="Windows Defender") OR (product_names="Sophos") OR (product_names="CrowdStrike") OR (product_names="Kaspersky"))), 1, 0))) as All, sum(eval(if(((product_names="Qualys") OR (product_names="Tenable")), 1, 0))) as Vulnerability_Scanner, sum(eval(if(((product_names="Windows Defender") OR (product_names="Sophos") OR (product_names="CrowdStrike")OR (product_names="Kaspersky")), 1, 0))) as Antivirus 
+| eval No_Lansweeper=Total-Lansweeper, No_Qualys=Total-Qualys, No_Tenable=Total-Tenable, No_Sophos=Total-Sophos, No_Defender=Total-Defender, No_CrowdStrike=Total-CrowdStrike, No_Kaspersky=Total-Kaspersky, No_Antivirus=Total-Antivirus, No_Vulnerability_Scanner=Total-Vulnerability_Scanner, No_Splunk_Internal=Total-Splunk_Internal</query>
     <earliest>0</earliest>
     <latest>now</latest>
   </search>
@@ -78,7 +78,7 @@
       <chart>
         <title>Number of Devices That Are Connected To A Specific Security Component</title>
         <search base="base_summary">
-          <query>| table Total, Lansweeper, Qualys, Tenable, Sophos, Defender, CrowdStrike, Kaspersky</query>
+          <query>| table Total, Lansweeper, Qualys, Tenable, Sophos, Defender, CrowdStrike, Kaspersky, Splunk_Internal</query>
         </search>
         <option name="charting.chart">bar</option>
         <option name="charting.chart.showDataLabels">all</option>
@@ -106,6 +106,9 @@
           <condition match="$click.name2$ == &quot;Kaspersky&quot;">
             <set token="tkn_sp_filter">kaspersky_last_event=*</set>
           </condition>
+          <condition match="$click.name2$ == &quot;Splunk_Internal&quot;">
+            <set token="tkn_sp_filter">product_names="Splunk Internal"</set>
+          </condition>
           <condition>
             <set token="tkn_sp_filter">()</set>
           </condition>
@@ -122,7 +125,7 @@
       <chart>
         <title>Number of Devices That Contain A Specific Security Component</title>
         <search base="base_summary">
-          <query>| table Total, All, Lansweeper, Vulnerability_Scanner, Antivirus</query>
+          <query>| table Total, All, Lansweeper, Vulnerability_Scanner, Antivirus, Splunk_Internal</query>
         </search>
         <option name="charting.chart">bar</option>
         <option name="charting.chart.showDataLabels">all</option>
@@ -130,7 +133,7 @@
         <option name="refresh.display">progressbar</option>
         <drilldown>
           <condition match="$click.name2$ == &quot;All&quot;">
-            <set token="tkn_sp_filter">((lansweeper_last_event=*) AND (tenable_last_event=* OR qualys_last_event=*) AND (sophos_last_event=* OR defender_last_event=* OR crowdstrike_last_event=* OR kaspersky_last_event=*))</set>
+            <set token="tkn_sp_filter">((lansweeper_last_event=*) AND (product_names="Splunk Internal") AND (tenable_last_event=* OR qualys_last_event=*) AND (sophos_last_event=* OR defender_last_event=* OR crowdstrike_last_event=* OR kaspersky_last_event=*))</set>
           </condition>
           <condition match="$click.name2$ == &quot;Lansweeper&quot;">
             <set token="tkn_sp_filter">lansweeper_last_event=*</set>
@@ -140,6 +143,9 @@
           </condition>
           <condition match="$click.name2$ == &quot;Antivirus&quot;">
             <set token="tkn_sp_filter">(sophos_last_event=* OR defender_last_event=* OR crowdstrike_last_event=* OR kaspersky_last_event=*)</set>
+          </condition>
+          <condition match="$click.name2$ == &quot;Splunk_Internal&quot;">
+            <set token="tkn_sp_filter">product_names="Splunk Internal"</set>
           </condition>
           <condition>
             <set token="tkn_sp_filter">()</set>
@@ -155,7 +161,7 @@
       <chart>
         <title>Number of Devices That Lack A Specific Security Component</title>
         <search base="base_summary">
-          <query>| table Total, No_Lansweeper, No_Vulnerability_Scanner, No_Antivirus</query>
+          <query>| table Total, No_Lansweeper, No_Vulnerability_Scanner, No_Antivirus, No_Splunk_Internal</query>
         </search>
         <option name="charting.chart">bar</option>
         <option name="charting.chart.showDataLabels">all</option>
@@ -170,6 +176,9 @@
           </condition>
           <condition match="$click.name2$ == &quot;No_Antivirus&quot;">
             <set token="tkn_sp_filter">NOT (sophos_last_event=* OR defender_last_event=* OR crowdstrike_last_event=* OR kaspersky_last_event=*)</set>
+          </condition>
+          <condition match="$click.name2$ == &quot;No_Splunk_Internal&quot;">
+            <set token="tkn_sp_filter">NOT (product_names="Splunk Internal")</set>
           </condition>
           <condition>
             <set token="tkn_sp_filter">()</set>

--- a/cyences_app_for_splunk/default/macros.conf
+++ b/cyences_app_for_splunk/default/macros.conf
@@ -210,7 +210,7 @@ definition = cyencesdevicemanager operation="getdevices" \
 | eval active_vul_qualys=ACTIVE-ACTIVE_SEVERITY_1, active_vul_tenable=active_vuln-info_active_vuln \
 | eval active_vul=coalesce(active_vul_qualys,active_vul_tenable), total_vul=coalesce(total_vuln,TOTAL_VULNS), severity_5_q=if(isnull(ACTIVE_SEVERITY_5), 0, ACTIVE_SEVERITY_5), severity_4_q=if(isnull(ACTIVE_SEVERITY_4), 0, ACTIVE_SEVERITY_4), high_vul_q=severity_5_q+severity_4_q, high_vul_t=critical_active_vuln+high_active_vuln, high_vul_q=if(isnull(high_vul_q), 0, high_vul_q), high_vul_t=if(isnull(high_vul_t), 0, high_vul_t), high_vul=high_vul_q+high_vul_t \
 | eval high_vul=if(high_vul==0, null(), high_vul) \
-| table _time, uuid, ip, hostname, mac_address, user, os, lansweeper, qualys, tenable, active_vul, high_vul, sophos, defender, crowdstrike,kaspersky, tmp_*, *_last_event, ip_drilldown, hostname_drilldown, user_drilldown \
+| table _time, product_names, uuid, ip, hostname, mac_address, user, os, lansweeper, qualys, tenable, active_vul, high_vul, sophos, defender, crowdstrike,kaspersky, tmp_*, *_last_event, ip_drilldown, hostname_drilldown, user_drilldown \
 | fields - crowdstrike_status, kaspersky_status, sophos_status, defender_status, tenable_status, qualys_status, lansweeper_status
 iseval = 0
 


### PR DESCRIPTION
- Added splunk internal devices as a product in device inventory dashboard
- For splunk internal logs, we do not maintain a specific lookup similar to other products hence its drilldown handled based on product_names field. 