### PR TITLE
Separated out the windows source and sourcetypes

### DIFF
--- a/cyences_app_for_splunk/bin/cs_product_list.py
+++ b/cyences_app_for_splunk/bin/cs_product_list.py
@@ -156,8 +156,8 @@ PRODUCTS = [
                 "label": "Linux Data",
                 "search_macro": "cs_linux",
                 "search_by": "sourcetype",
-                "search_values": "usersWithLoginPrivs,cyences:linux:groups,cyences:linux:users,sudousers,openPorts,interfaces,df,Unix:ListeningPorts,Unix:Service,Unix:UserAccounts,Unix:Version,Unix:Uptime,package,hardware,lsof,linux_secure,linux:audit,syslog",
-                "search_more": "sourcetype IN (usersWithLoginPrivs,cyences:linux:groups,cyences:linux:users,sudousers,openPorts,interfaces,df,Unix:ListeningPorts,Unix:Service,Unix:UserAccounts,Unix:Version,Unix:Uptime,package,hardware,lsof,linux_secure,linux:audit,syslog)",
+                "search_values": "usersWithLoginPrivs,cyences:linux:groups,cyences:linux:users,sudousers,openPorts,interfaces,df,Unix:ListeningPorts,Unix:Service,Unix:UserAccounts,Unix:Version,Unix:Uptime,package,hardware,lsof,linux_secure,linux:audit",
+                "search_more": "sourcetype IN (usersWithLoginPrivs,cyences:linux:groups,cyences:linux:users,sudousers,openPorts,interfaces,df,Unix:ListeningPorts,Unix:Service,Unix:UserAccounts,Unix:Version,Unix:Uptime,package,hardware,lsof,linux_secure,linux:audit)",
                 "earliest_time": "-2d@d",
                 "latest_time": "now",
             }
@@ -320,23 +320,79 @@ PRODUCTS = [
     },
     {
         "name": "Windows",
-        "metadata_count_search": "| tstats count where `cs_windows_idx` OR (index=* sourcetype IN (*WinEventLog,MSAD:*:Health,ActiveDirectory) OR source IN (*WinEventLog:Security,*WinEventLog:System,powershell*))",
+        "metadata_count_search": '| tstats count where ((`cs_windows_idx`) OR (index=* sourcetype IN ("*WinEventLog","ActiveDirectory") OR source IN ("*WinEventLog:Security","*WinEventLog:System","powershell*"))) NOT source IN ("WinEventLog:DFS Replication","WinEventLog:Directory Service","WinEventLog:Microsoft-AzureADPasswordProtection-DCAgent/Admin","PerfmonMk:DFS_Replicated_Folders","WinEventLog:DNS Server") NOT sourcetype IN ("MSAD:NT6:Netlogon","MSAD:NT6:Replication","MSAD:NT6:Health","MSAD:NT6:SiteInfo","Script:TimesyncConfiguration","Script:TimesyncStatus","windows:certstore:ca:issued","MSAD:NT6:DNS","MSAD:NT6:DNS-Health","MSAD:NT6:DNS-Zone-Information","PerfmonMk:DNS") ',
         "macro_configurations": [
             {
                 "macro_name": "cs_windows_idx",
                 "label": "Windows Data",
-                "search": r"""`cs_windows_idx` | stats count | eval label="Windows" 
+                "search": r"""`cs_windows_idx` NOT source IN ("WinEventLog:DFS Replication","WinEventLog:Directory Service","WinEventLog:Microsoft-AzureADPasswordProtection-DCAgent/Admin","PerfmonMk:DFS_Replicated_Folders","WinEventLog:DNS Server") NOT sourcetype IN ("MSAD:NT6:Netlogon","MSAD:NT6:Replication","MSAD:NT6:Health","MSAD:NT6:SiteInfo","Script:TimesyncConfiguration","Script:TimesyncStatus","windows:certstore:ca:issued","MSAD:NT6:DNS","MSAD:NT6:DNS-Health","MSAD:NT6:DNS-Zone-Information","PerfmonMk:DNS") | stats count | eval label="Windows" 
 | append [| search `cs_windows_idx` sourcetype="*WinEventLog" source="*WinEventLog:Security" | stats count | eval label="Windows Security", search="sourcetype=\"*WinEventLog\" source=\"*WinEventLog:Security\""] 
 | append [| search `cs_windows_idx` sourcetype="*WinEventLog" source="*WinEventLog:System" | stats count | eval label="Windows System", search="sourcetype=\"*WinEventLog\" source=\"*WinEventLog:System\""] 
 | append [| search `cs_windows_idx` sourcetype="ActiveDirectory" | stats count | eval label="Windows AD", search="sourcetype=\"ActiveDirectory\""] 
-| append [| search `cs_windows_idx` source=powershell sourcetype="MSAD:*:Health" | stats count | eval label="Windows AD Health", search="source=powershell sourcetype=\"MSAD:*:Health\""] 
 | table label search count""",
-                "host_reviewer_search": '| tstats count where `cs_windows_idx` by source sourcetype host | eval sources = source." (".sourcetype.")" | table sources host count',
-                "sources_reviewer_search": r"""| tstats values(host) as hosts where `cs_windows_idx` by source sourcetype index | eval sources = source." (".sourcetype.")" | stats count values(index) as index dc(hosts) as host_count by sources | eval sources=if(count>0,sources,"`cs_windows_idx`") | append [
+                "host_reviewer_search": '| tstats count where ((`cs_windows_idx`) OR (index=* sourcetype IN ("*WinEventLog","ActiveDirectory") OR source IN ("*WinEventLog:Security","*WinEventLog:System","powershell*"))) NOT source IN ("WinEventLog:DFS Replication","WinEventLog:Directory Service","WinEventLog:Microsoft-AzureADPasswordProtection-DCAgent/Admin","PerfmonMk:DFS_Replicated_Folders","WinEventLog:DNS Server") NOT sourcetype IN ("MSAD:NT6:Netlogon","MSAD:NT6:Replication","MSAD:NT6:Health","MSAD:NT6:SiteInfo","Script:TimesyncConfiguration","Script:TimesyncStatus","windows:certstore:ca:issued","MSAD:NT6:DNS","MSAD:NT6:DNS-Health","MSAD:NT6:DNS-Zone-Information","PerfmonMk:DNS") by source sourcetype host | eval sources = if(sourcetype IN ("WinEventLog","WinHostMon","exec","XmlWinEventLog*","powershell"),source,sourcetype) | stats sum(count) as count by sources host',
+                "sources_reviewer_search": r"""| tstats values(host) as hosts where ((`cs_windows_idx`) OR (index=* sourcetype IN ("*WinEventLog","ActiveDirectory") OR source IN ("*WinEventLog:Security","*WinEventLog:System","powershell*"))) NOT source IN ("WinEventLog:DFS Replication","WinEventLog:Directory Service","WinEventLog:Microsoft-AzureADPasswordProtection-DCAgent/Admin","PerfmonMk:DFS_Replicated_Folders","WinEventLog:DNS Server") NOT sourcetype IN ("MSAD:NT6:Netlogon","MSAD:NT6:Replication","MSAD:NT6:Health","MSAD:NT6:SiteInfo","Script:TimesyncConfiguration","Script:TimesyncStatus","windows:certstore:ca:issued","MSAD:NT6:DNS","MSAD:NT6:DNS-Health","MSAD:NT6:DNS-Zone-Information","PerfmonMk:DNS") by source sourcetype index | eval sources = if(sourcetype IN ("WinEventLog","WinHostMon","exec","XmlWinEventLog*","powershell"),source,sourcetype) | stats count values(index) as index dc(hosts) as host_count by sources | eval sources=if(count>0,sources,"`cs_windows_idx`") | append [
 | tstats values(host) as hosts where index=* sourcetype="*WinEventLog" source="*WinEventLog:Security" by source sourcetype index | eval sources = source." (".sourcetype.")" | stats count values(index) as index dc(hosts) as host_count by sources | stats count values(*) as * | eval sources=if(count>0,sources,"WinEventLog:Security (WinEventLog)")] | append [
 | tstats values(host) as hosts where index=* sourcetype="*WinEventLog" source="*WinEventLog:System" by source sourcetype index | eval sources = source." (".sourcetype.")" | stats count values(index) as index dc(hosts) as host_count by sources | stats count values(*) as * | eval sources=if(count>0,sources,"WinEventLog:System (WinEventLog)")] | append [
-| tstats values(host) as hosts where index=* source="powershell*" sourcetype="MSAD:*:Health" by source sourcetype index | eval sources = source." (".sourcetype.")" | stats count values(index) as index dc(hosts) as host_count by sources | stats count values(*) as * | eval sources=if(count>0,sources,"powershell (MSAD:*:Health)")] | append [
 | tstats values(host) as hosts where index=* sourcetype="ActiveDirectory" by sourcetype index | stats count values(index) as index dc(hosts) as host_count by sourcetype | stats count values(*) as * | eval sourcetype=if(count>0,sourcetype,"ActiveDirectory")  | rename sourcetype as sources]""",
+                "earliest_time": "-1d@d",
+                "latest_time": "now",
+            }
+        ],
+    },
+    {
+        "name": "Windows AD",
+        "metadata_count_search": '| tstats count where index=* source IN ("WinEventLog:DFS Replication","WinEventLog:Directory Service","WinEventLog:Microsoft-AzureADPasswordProtection-DCAgent/Admin","PerfmonMk:DFS_Replicated_Folders") OR sourcetype IN ("MSAD:NT6:Netlogon","MSAD:NT6:Replication","MSAD:NT6:Health","MSAD:NT6:SiteInfo","Script:TimesyncConfiguration","Script:TimesyncStatus","windows:certstore:ca:issued") ',
+        "macro_configurations": [
+            {
+                "macro_name": "cs_windows_idx",
+                "label": "Windows AD Data",
+                "search": r"""| tstats count where index=* source="WinEventLog:DFS Replication" by source | rename source as sources | stats count | eval sources=if(count>0, sources, "WinEventLog:DFS Replication") | append [
+                | tstats count where index=* source="WinEventLog:Directory Service" by source | rename source as sources | stats count | eval sources=if(count>0, sources, "WinEventLog:Directory Service")] | append [
+                | tstats count where index=* source="WinEventLog:Microsoft-AzureADPasswordProtection-DCAgent/Admin" by source | rename source as sources | stats count | eval sources=if(count>0, sources, "WinEventLog:Microsoft-AzureADPasswordProtection-DCAgent/Admin")] | append [
+                | tstats count where index=* source="PerfmonMk:DFS_Replicated_Folders" by source | rename source as sources | stats count | eval sources=if(count>0, sources, "PerfmonMk:DFS_Replicated_Folders")] | append [
+                | tstats count where index=* sourcetype="MSAD:NT6:Netlogon" by sourcetype | rename sourcetype as sources | stats count | eval sources=if(count>0, sources, "MSAD:NT6:Netlogon")] | append [
+                | tstats count where index=* sourcetype="MSAD:NT6:Replication" by sourcetype  | rename sourcetype as sources | stats count | eval sources=if(count>0, sources, "MSAD:NT6:Replication")] | append [
+                | tstats count where index=* sourcetype="MSAD:NT6:Health" by sourcetype  | rename sourcetype as sources | stats count | eval sources=if(count>0, sources, "MSAD:NT6:Health")] | append [
+                | tstats count where index=* sourcetype="MSAD:NT6:SiteInfo" by sourcetype | rename sourcetype as sources | stats count | eval sources=if(count>0, sources, "MSAD:NT6:SiteInfo")] | append [
+                | tstats count where index=* sourcetype="Script:TimesyncConfiguration" by sourcetype | rename sourcetype as sources | stats count | eval sources=if(count>0, sources, "Script:TimesyncConfiguration")] | append [
+                | tstats count where index=* sourcetype="Script:TimesyncStatus" by sourcetype | rename sourcetype as sources | stats count | eval sources=if(count>0, sources, "Script:TimesyncStatus")] | append [
+                | tstats count where index=* sourcetype="windows:certstore:ca:issued" by sourcetype | rename sourcetype as sources | stats count | eval sources=if(count>0, sources, "windows:certstore:ca:issued")] """,
+                "host_reviewer_search": '| tstats count where index=* source IN ("WinEventLog:DFS Replication","WinEventLog:Directory Service","WinEventLog:Microsoft-AzureADPasswordProtection-DCAgent/Admin","PerfmonMk:DFS_Replicated_Folders") OR sourcetype IN ("MSAD:NT6:Netlogon","MSAD:NT6:Replication","MSAD:NT6:Health","MSAD:NT6:SiteInfo","Script:TimesyncConfiguration","Script:TimesyncStatus","windows:certstore:ca:issued") by source sourcetype host | eval sources = if(source IN ("WinEventLog:DFS Replication","WinEventLog:Directory Service","WinEventLog:Microsoft-AzureADPasswordProtection-DCAgent/Admin","PerfmonMk:DFS_Replicated_Folders"), source, sourcetype) | stats sum(count) as count by sources host',
+                "sources_reviewer_search": r"""| tstats values(host) as hosts where index=* source="WinEventLog:DFS Replication" by source index | rename source as sources | stats count values(index) as index dc(hosts) as host_count by sources | stats count values(*) as * | eval sources=if(count>0,sources,"WinEventLog:DFS Replication") | append [
+                | tstats values(host) as hosts where index=* source="WinEventLog:Directory Service" by source index | rename source as sources | stats count values(index) as index dc(hosts) as host_count by sources | stats count values(*) as * | eval sources=if(count>0,sources,"WinEventLog:Directory Service")] | append [
+                | tstats values(host) as hosts where index=* source="WinEventLog:Microsoft-AzureADPasswordProtection-DCAgent/Admin" by source index | rename source as sources | stats count values(index) as index dc(hosts) as host_count by sources | stats count values(*) as * | eval sources=if(count>0,sources,"WinEventLog:Microsoft-AzureADPasswordProtection-DCAgent/Admin")] | append [
+                | tstats values(host) as hosts where index=* source="PerfmonMk:DFS_Replicated_Folders" by source index | rename source as sources | stats count values(index) as index dc(hosts) as host_count by sources | stats count values(*) as * | eval sources=if(count>0,sources,"PerfmonMk:DFS_Replicated_Folders")] | append [
+                | tstats values(host) as hosts where index=* sourcetype="MSAD:NT6:Netlogon" by sourcetype index | rename sourcetype as sources | stats count values(index) as index dc(hosts) as host_count by sources | stats count values(*) as * | eval sourcetype=if(count>0,sourcetype,"MSAD:NT6:Netlogon")] | append [
+                | tstats values(host) as hosts where index=* sourcetype="MSAD:NT6:Replication" by sourcetype index | rename sourcetype as sources | stats count values(index) as index dc(hosts) as host_count by sources | stats count values(*) as * | eval sourcetype=if(count>0,sourcetype,"MSAD:NT6:Replication")] | append [
+                | tstats values(host) as hosts where index=* sourcetype="MSAD:NT6:Health" by sourcetype index | rename sourcetype as sources | stats count values(index) as index dc(hosts) as host_count by sources | stats count values(*) as * | eval sourcetype=if(count>0,sourcetype,"MSAD:NT6:Health")] | append [
+                | tstats values(host) as hosts where index=* sourcetype="MSAD:NT6:SiteInfo" by sourcetype index | rename sourcetype as sources | stats count values(index) as index dc(hosts) as host_count by sources | stats count values(*) as * | eval sourcetype=if(count>0,sourcetype,"MSAD:NT6:SiteInfo")] | append [
+                | tstats values(host) as hosts where index=* sourcetype="Script:TimesyncConfiguration" by sourcetype index | rename sourcetype as sources | stats count values(index) as index dc(hosts) as host_count by sources | stats count values(*) as * | eval sourcetype=if(count>0,sourcetype,"Script:TimesyncConfiguration")] | append [
+                | tstats values(host) as hosts where index=* sourcetype="Script:TimesyncStatus" by sourcetype index | rename sourcetype as sources | stats count values(index) as index dc(hosts) as host_count by sources | stats count values(*) as * | eval sourcetype=if(count>0,sourcetype,"Script:TimesyncStatus")] | append [
+                | tstats values(host) as hosts where index=* sourcetype="windows:certstore:ca:issued" by sourcetype index | rename sourcetype as sources | stats count values(index) as index dc(hosts) as host_count by sources | stats count values(*) as * | eval sourcetype=if(count>0,sourcetype,"windows:certstore:ca:issued")]""",
+                "earliest_time": "-1d@d",
+                "latest_time": "now",
+            }
+        ],
+    },
+    {
+        "name": "Windows DNS",
+        "metadata_count_search": '| tstats count where index=* source IN ("WinEventLog:DNS Server") OR sourcetype IN ("MSAD:NT6:DNS","MSAD:NT6:DNS-Health","MSAD:NT6:DNS-Zone-Information","PerfmonMk:DNS") ',
+        "macro_configurations": [
+            {
+                "macro_name": "cs_windows_idx",
+                "label": "Windows DNS Data",
+                "search": r"""| tstats count where index=* source="WinEventLog:DNS Server" by source | rename source as sources | stats count | eval sources=if(count>0, sources, "WinEventLog:DNS Server") | append [
+                | tstats count where index=* sourcetype="MSAD:NT6:DNS" by sourcetype | rename sourcetype as sources | stats count | eval sources=if(count>0, sources, "MSAD:NT6:DNS")] | append [
+                | tstats count where index=* sourcetype="MSAD:NT6:DNS-Health" by sourcetype  | rename sourcetype as sources | stats count | eval sources=if(count>0, sources, "MSAD:NT6:DNS-Health")] | append [
+                | tstats count where index=* sourcetype="MSAD:NT6:DNS-Zone-Information" by sourcetype  | rename sourcetype as sources | stats count | eval sources=if(count>0, sources, "MSAD:NT6:DNS-Zone-Information")] | append [
+                | tstats count where index=* sourcetype="PerfmonMk:DNS" by sourcetype | rename sourcetype as sources | stats count | eval sources=if(count>0, sources, "PerfmonMk:DNS")]""",
+                "host_reviewer_search": '| tstats count where index=* source IN ("WinEventLog:DNS Server") OR sourcetype IN ("MSAD:NT6:DNS","MSAD:NT6:DNS-Health","MSAD:NT6:DNS-Zone-Information","PerfmonMk:DNS") by source sourcetype host | eval sources = if(source=="WinEventLog:DNS Server", source, sourcetype) | stats sum(count) as count by sources host',
+                "sources_reviewer_search": r"""| tstats values(host) as hosts where index=* source="WinEventLog:DNS Server" by source index | rename source as sources | stats count values(index) as index dc(hosts) as host_count by sources | stats count values(*) as * | eval sources=if(count>0,sources,"WinEventLog:DNS Server") | append [
+                | tstats values(host) as hosts where index=* sourcetype="MSAD:NT6:DNS" by sourcetype index | rename sourcetype as sources | stats count values(index) as index dc(hosts) as host_count by sources | stats count values(*) as * | eval sourcetype=if(count>0,sourcetype,"MSAD:NT6:DNS")] | append [
+                | tstats values(host) as hosts where index=* sourcetype="MSAD:NT6:DNS-Health" by sourcetype index | rename sourcetype as sources | stats count values(index) as index dc(hosts) as host_count by sources | stats count values(*) as * | eval sourcetype=if(count>0,sourcetype,"MSAD:NT6:DNS-Health")] | append [
+                | tstats values(host) as hosts where index=* sourcetype="MSAD:NT6:DNS-Zone-Information" by sourcetype index | rename sourcetype as sources | stats count values(index) as index dc(hosts) as host_count by sources | stats count values(*) as * | eval sourcetype=if(count>0,sourcetype,"MSAD:NT6:DNS-Zone-Information")] | append [
+                | tstats values(host) as hosts where index=* sourcetype="PerfmonMk:DNS" by sourcetype index | rename sourcetype as sources | stats count values(index) as index dc(hosts) as host_count by sources | stats count values(*) as * | eval sourcetype=if(count>0,sourcetype,"PerfmonMk:DNS")]""",
                 "earliest_time": "-1d@d",
                 "latest_time": "now",
             }


### PR DESCRIPTION
Separated following sources/sourcetypes of windows:

**windows AD**
source
-------
WinEventLog:DFS Replication
WinEventLog:Directory Service
WinEventLog:Microsoft-AzureADPasswordProtection-DCAgent/Admin
PerfmonMk:DFS_Replicated_Folders

sourcetypes
---------------
MSAD:NT6:Netlogon
MSAD:NT6:Replication
MSAD:NT6:Health
MSAD:NT6:SiteInfo
Script:TimesyncConfiguration
Script:TimesyncStatus
windows:certstore:ca:issued

=====================
**Windows DNS**
source
--------
WinEventLog:DNS Server

sourcetypes
--------------
MSAD:NT6:DNS
MSAD:NT6:DNS-Health
MSAD:NT6:DNS-Zone-Information
PerfmonMk:DNS

NOTE: You can see changes on the Cerberos.