### PR TITLE
Fixed incorrect username issue in user changes alert.

### DIFF
--- a/cyences_app_for_splunk/default/macros.conf
+++ b/cyences_app_for_splunk/default/macros.conf
@@ -517,12 +517,12 @@ definition = fillnull value="" signature,Correlation_IDs\
 iseval = 0
 
 [ms_obj_user_change_out]
-definition = fields _time,Message, ComputerName, src_user, user, user_obj_dn, user_obj_email,msad_action, MSADChanges, dest_nt_domain, signature, change_signature, MSADChangedAttributes,Correlation_ID,AttributeLDAPDisplayName,AttributeValue,DN,Old_DN,New_DN,dir_svcs_action\
+definition = fields _time,Message, ComputerName, src_user, user, Target_Account_Name, user_obj_dn, user_obj_email,msad_action, MSADChanges, dest_nt_domain, signature, change_signature, MSADChangedAttributes,Correlation_ID,AttributeLDAPDisplayName,AttributeValue,DN,Old_DN,New_DN,dir_svcs_action\
 | eval adminuser=if(isnull(src_nt_domain),src_user,upper(src_nt_domain)."\\".src_user)\
 | eval user_obj_lkp=if(isnull(user_obj_dn),if(isnull(user_obj_email),if(isnull(DN),if(isnull(Old_DN),if(isnull(New_DN),lower(user),lower(New_DN)),lower(Old_DN)),lower(DN)),lower(user_obj_email)),lower(user_obj_dn))\
 | lookup cs_ad_obj_user lookup_usr AS user_obj_lkp OUTPUT sAMAccountName AS b_user_obj_sam,cn AS b_user_obj_cn\
 | eval user=if(isnull(b_user_obj_sam),if(isnull(b_user_obj_cn),if(isnull(user_obj_lkp),"NA",lower(user_obj_lkp)),lower(b_user_obj_cn)),lower(b_user_obj_sam))\
-| eval user=mvindex(user,0)\
+| eval user=coalesce(Target_Account_Name, mvindex(user,0))\
 | eval dest_user_subject=if(isnull(dest_nt_domain),user,dest_nt_domain."\\".lower(user))\
 | eval signature=coalesce(change_signature, signature)\
 | `ms_obj_msad-changed-attributes`\


### PR DESCRIPTION
Due to special character in target_username field, user field is getting extracted incorrectly. so updated the field that contains the correct username.
Reference : [Jira](https://crossrealms.atlassian.net/browse/CY-750)
 